### PR TITLE
added cv_bridge image types

### DIFF
--- a/importRosbag/messageTypes/sensor_msgs_Image.py
+++ b/importRosbag/messageTypes/sensor_msgs_Image.py
@@ -66,12 +66,21 @@ def importTopic(msgs, **kwargs):
         if fmtString in ['mono8', '8UC1']:
             frameData = np.frombuffer(data[ptr:ptr+height*width],np.uint8)
             depth = 1
+        elif fmtString in ['mono16', '16UC1']:
+            frameData = np.frombuffer(data[ptr:ptr+height*width*2],np.uint16)
+            depth = 1
+        elif fmtString in ['bgr8', 'rgb8']:
+            frameData = np.frombuffer(data[ptr:ptr+height*width*3],np.uint8)
+            depth = 3
+        elif fmtString in ['bgra8', 'rgba8']:
+            frameData = np.frombuffer(data[ptr:ptr+height*width*4],np.uint8)
+            depth = 4
+        elif fmtString == '16SC1':
+            frameData = np.frombuffer(data[ptr:ptr+height*width*2],np.int16)
+            depth = 1
         elif fmtString == '32FC1':
             frameData = np.frombuffer(data[ptr:ptr+height*width*4],np.float32)
             depth = 1
-        elif fmtString == 'bgr8':
-            frameData = np.frombuffer(data[ptr:ptr+height*width*3],np.uint8)
-            depth = 3 
         else:
             print('image format not supported:' + fmtString)
             return None


### PR DESCRIPTION
Thank you for the very useful code.

I found it useful to have an image type compatible with cv_bridge.
The following types have been added and operation has been confirmedwith the ROS1 melodic bag file.

If you like it please merge.

- mono8: CV_8UC1, grayscale image
- mono16: CV_16UC1, 16-bit grayscale image
- bgr8: CV_8UC3, color image with blue-green-red color order
- rgb8: CV_8UC3, color image with red-green-blue color order
- bgra8: CV_8UC4, BGR color image with an alpha channel
- rgba8: CV_8UC4, RGB color image with an alpha channel

- 8UC[1-4]
- 8SC[1-4]
- 16UC[1-4]
- 16SC[1-4]

<http://wiki.ros.org/cv_bridge/Tutorials/ConvertingBetweenROSImagesAndOpenCVImagesPython>
