### PR TITLE
Remove deprecated np.bool from dvs_msgs_EventArray.py

### DIFF
--- a/importRosbag/messageTypes/dvs_msgs_EventArray.py
+++ b/importRosbag/messageTypes/dvs_msgs_EventArray.py
@@ -64,7 +64,7 @@ def importTopic(msgs, **kwargs):
                dataAsArray[:, 10] * 2**16 + \
                dataAsArray[:, 11] * 2**24).astype(np.float64))
         tsByMessage.append(ts + tns / 1000000000) # Combine timestamp parts, result is in seconds
-        polByMessage.append(dataAsArray[:, 12].astype(np.bool))
+        polByMessage.append(dataAsArray[:, 12].astype(bool))
     outDict = {
         'x': np.concatenate(xByMessage),
         'y': np.concatenate(yByMessage),


### PR DESCRIPTION
According to NumPy release 1.24.0, np.bool is deprecated and throws an error.

https://github.com/numpy/numpy/releases/tag/v1.24.0